### PR TITLE
Update remmina-encode-password.py to work with Python3

### DIFF
--- a/remmina/remmina-encode-password.py
+++ b/remmina/remmina-encode-password.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 import base64
 import os
 import re
 import sys
-from Crypto.Cipher import DES3
+from Cryptodome.Cipher import DES3
 from os.path import expanduser
 
 home = expanduser("~")
@@ -31,4 +31,4 @@ result = cipher.encrypt(plain)
 result = base64.b64encode(result)
 result = result.decode('utf-8')
 
-print result
+print(result)


### PR DESCRIPTION
Adjustments to the shabang, print() use, and using a different Crypto module (Cryptodome instead of Crypto) to make this code working on Python. Tested on Ubuntu 22.04